### PR TITLE
Fix tool hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 ## Tools
 
 We use:
-- [Slack](www.slack.com) for chat communication; incl. hooks from other tools (e.g. GitHub) and bots (e.g. [Github Release Notifier](https://github.com/justwatchcom/github-releases-notifier))
-- [GitHub](www.github.com/berops) for private and public git repositories
-- [GSuite](gsuite.google.com) for mailbox, cloud storage and other office tools
-- [Google Cloud Platform](cloud.google.com) for hosting our infrastructure
-- [Nuclino](www.nuclino.com) as a team WIKI
-- [Miro](www.miro.com) for diagrams and charts
+- [Slack](https://www.slack.com) for chat communication; incl. hooks from other tools (e.g. GitHub) and bots (e.g. [Github Release Notifier](https://github.com/justwatchcom/github-releases-notifier))
+- [GitHub](https://www.github.com/berops) for private and public git repositories
+- [GSuite](https://gsuite.google.com) for mailbox, cloud storage and other office tools
+- [Google Cloud Platform](https://cloud.google.com) for hosting our infrastructure
+- [Nuclino](https://www.nuclino.com) as a team WIKI
+- [Miro](https://www.miro.com) for diagrams and charts
 
 <a name="git">
 


### PR DESCRIPTION
Tool hyperlinks linked to GitHub ( e.g. _www.slack.com_ -> _https://github.com/Berops/culture/blob/main/www.slack.com_ ). 
Fixed by adding _https://_ to the links.