### PR TITLE
Add policy for HW equipment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If the person is located within an EU country, the company procures the working 
 
 We offer a EUR 500.- budget for a working desk and EUR 500.- budget for a chair.
 
-This program is optional and people who prefeir to use their own hardware or other equipment are most welcome to do so.
+This program is optional and people who prefer to use their own hardware or other equipment are most welcome to do so.
 
 ### What happens to the equipment if I leave the company?
 


### PR DESCRIPTION
This policy should answer typical questions about whether and how do
we provide the equipment for our colleagues and what is the relevant
process if they decide to resign.