### PR TITLE
Add merge policy for the private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ All our work is stored on GitHub in private and public repositories. There are c
 - anybody can review and merge anybody else's PR (except of his/her own one)
 - we care about the commit and PR [hygiene](https://chris.beams.io/posts/git-commit/)
 - we require rebase, fast-forward merge policy (`rebase + merge --ff-only`) on open-sourced repositories
+- we require [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) policy on private repositories
 
 <a name="communication">
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ All our work is stored on GitHub in private and public repositories. There are c
 - PRs get merged after a review; review needs to be done by s/b else than the person who logged the PR
 - anybody can review and merge anybody else's PR (except of his/her own one)
 - we care about the commit and PR [hygiene](https://chris.beams.io/posts/git-commit/)
-- we require rebase, fast-forward merge policy (`rebase + merge --ff-only`) on open-sourced repositories
-- we require [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) policy on private repositories
+- we require rebase, fast-forward merge policy (`rebase + merge --ff-only`) on __all__ repositories
+- we require [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) policy on __all__ repositories
 
 <a name="communication">
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ All our work is stored on GitHub in private and public repositories. There are c
 - PRs get merged after a review; review needs to be done by s/b else than the person who logged the PR
 - anybody can review and merge anybody else's PR (except of his/her own one)
 - we care about the commit and PR [hygiene](https://chris.beams.io/posts/git-commit/)
-- we require rebase, fast-forward merge policy (`rebase + merge --ff-only`) on __all__ repositories
-- we require [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) policy on __all__ repositories
+- PRs should be merged via the [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) button
 
 <a name="communication">
 


### PR DESCRIPTION
# Description
We faced a bit confusion today while merging the latest PR. The merge policy for our private repos is not defined here but i was told that we follow `squash and merge` policy only. To avoid such confusion in future, I have mentioned this policy under `git` section of the readme file.